### PR TITLE
feat: add Item_Model support for Paper 1.21.4+

### DIFF
--- a/src/main/java/com/cjcrafter/armormechanics/Armor.kt
+++ b/src/main/java/com/cjcrafter/armormechanics/Armor.kt
@@ -5,26 +5,37 @@ import me.deecaad.core.file.Serializer
 import me.deecaad.core.file.SerializerException
 import me.deecaad.core.file.serializers.ItemSerializer
 import me.deecaad.weaponmechanics.utils.CustomTag
+import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.ItemMeta
 
 class Armor : Serializer<Armor> {
 
     lateinit var armorTitle: String
         private set
     private lateinit var itemStack: ItemStack
+    private var itemModel: NamespacedKey? = null
 
     /**
      * Default constructor for serializer.
      */
     constructor()
 
-    constructor(armorTitle: String, itemStack: ItemStack) {
+    constructor(armorTitle: String, itemStack: ItemStack, itemModel: NamespacedKey? = null) {
         this.armorTitle = armorTitle
         this.itemStack = itemStack
+        this.itemModel = itemModel
     }
 
     fun generateItemStack(): ItemStack {
-        return itemStack.clone()
+        val item = itemStack.clone()
+        val model = itemModel ?: return item
+        if (!SUPPORTS_ITEM_MODEL) return item
+
+        val meta = item.itemMeta ?: return item
+        meta.setItemModel(model)
+        item.setItemMeta(meta)
+        return item
     }
 
     @Throws(SerializerException::class)
@@ -45,6 +56,23 @@ class Armor : Serializer<Armor> {
         CustomTag.ARMOR_TITLE.setString(item, title)
         item = itemSerializer.serializeRecipe(data, item)
 
-        return Armor(title, item)
+        // Parse optional Item_Model (requires Paper 1.21.4+)
+        val itemModel: NamespacedKey? = data.of("Item_Model").getNamespacedKey().orElse(null)
+
+        return Armor(title, item, itemModel)
+    }
+
+    companion object {
+        /**
+         * True when the server is running Paper 1.21.4 or newer, which added
+         * the `item_model` data component and the corresponding
+         * [ItemMeta.setItemModel] API method.
+         */
+        val SUPPORTS_ITEM_MODEL: Boolean = try {
+            ItemMeta::class.java.getDeclaredMethod("setItemModel", NamespacedKey::class.java)
+            true
+        } catch (_: NoSuchMethodException) {
+            false
+        }
     }
 }

--- a/src/main/resources/ArmorMechanics/armors/Armor.yml
+++ b/src/main/resources/ArmorMechanics/armors/Armor.yml
@@ -85,6 +85,9 @@ Scuba_Boots:
 
 Tactical_Helmet:
   Type: LEATHER_HELMET
+  # Item_Model overrides the visual model of the item using a resource pack.
+  # Requires Paper 1.21.4+. Format: 'namespace:key' (e.g. 'myplugin:tactical_helmet').
+  Item_Model:
   Name: "<yellow>Tactical Helmet"
   Lore:
     - "<gray>Now with night vision goggles!"
@@ -124,6 +127,7 @@ Tactical_Chestplate:
 
 Tactical_Leggings:
   Type: LEATHER_LEGGINGS
+  Item_Model:
   Name: "<yellow>Tactical Leggings"
   Lore:
     - "<gray>Getting shot in the leg hurts, so wear this"


### PR DESCRIPTION
Allows armor items to use the item_model data component to override their visual model via a resource pack. Falls back gracefully on servers that do not support the API (pre-1.21.4).